### PR TITLE
Changed grail faction bonus limiter from greenhouse to glasshouse

### DIFF
--- a/Greenhouse/content/config/buildings.json
+++ b/Greenhouse/content/config/buildings.json
@@ -302,7 +302,7 @@
 							"propagator" : "GLOBAL_EFFECT",
 							"limiters" : [ {
 								"type" : "CREATURE_FACTION_LIMITER",
-								"parameters" : ["greenhouse"]
+								"parameters" : ["glasshouse"]
 							} ]
 						}
 					]

--- a/Greenhouse/mod.json
+++ b/Greenhouse/mod.json
@@ -3,7 +3,7 @@
 	"description" : "Greenhouse - Town of Vegetables and Fruits.",
 	"author" : "Mad Hatter Workshop",
 	"contact" : "http://heroescommunity.com/viewthread.php3?TID=42323",
-	"version" : "0.1.8",
+	"version" : "0.1.9",
 	"modType" : "Town",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
@@ -13,6 +13,7 @@
 	},
 	"changelog" :
     {
+		"0.1.9"   : [ "fixed Grail bonus faction limiter" ],
 		"0.1.8"   : [ "New bonus for Grail building" ],
 		"0.1.7"   : [ "Working two special buildings" ],
 		"0.1.6"   : [ "Update to vcmi-1.3", "Arrow tower icons added" ],


### PR DESCRIPTION
Because that's the faction's technical name